### PR TITLE
chore: update aws provider to 6 in root terragrunt

### DIFF
--- a/root.hcl
+++ b/root.hcl
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
## What is the Feature / Change Being Made?

Renovate saw we can update AWS provider to version 6. Need to update the root terragrunt as that's where the provider files are generated from.

## What is the Rationale in Relation to Best Practices?

Dependency update, security best practices

## How Has This Been Tested?

Tested locally running setup docs and terragrunt commands to ensure no errors

## How Can the Community Use This?

n/a dep update

## Links to Related Issues or Discussions

renovate dep update

### Contribution Reminders

Your PR needs:
- At least 5 thumbs up from members of the community to be approved / merged
- Final review / approval from at least one maintainer
- Clear, complete, and fully usable code for real-world systems
- No placeholder, unfinished, or copied code with incompatible licensing
- No redundant comments or unrelated artifacts
- The PR title to follow conventional commit standards

Refer the CONTRIBUTING guidelines and CODE_OF_CONDUCT for more information.
