### PR TITLE
fix: use terragrunt setup gh action

### DIFF
--- a/.github/workflows/lint-and-test-infra.yaml
+++ b/.github/workflows/lint-and-test-infra.yaml
@@ -36,11 +36,9 @@ jobs:
           terraform_version: ${{ steps.get-versions.outputs.terraform_version }}
 
       - name: Setup Terragrunt
-        run: |
-          wget -q https://github.com/gruntwork-io/terragrunt/releases/download/v${{ steps.get-versions.outputs.terragrunt_version }}/terragrunt_linux_amd64 -O /tmp/terragrunt
-          chmod +x /tmp/terragrunt
-          sudo mv /tmp/terragrunt /usr/local/bin/terragrunt
-          terragrunt --version
+        uses: gruntwork-io/terragrunt-action@v3
+        with:
+          tg_version: ${{ steps.get-versions.outputs.terragrunt_version }}
 
       - name: Setup Terraform and Terragrunt Cache
         uses: actions/cache@v4

--- a/.github/workflows/lint-and-test-infra.yaml
+++ b/.github/workflows/lint-and-test-infra.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: gruntwork-io/terragrunt-action@v3
         with:
           tg_version: ${{ steps.get-versions.outputs.terragrunt_version }}
+          tf_path: "terraform"
 
       - name: Setup Terraform and Terragrunt Cache
         uses: actions/cache@v4


### PR DESCRIPTION
## What is the Feature / Change Being Made?

Update custom Terragrunt setup to use the Terragrunt setup github action now that it can be done without any commands.

## What is the Rationale in Relation to Best Practices?

Infra test job currently broken

## How Has This Been Tested?

Testing here

## How Can the Community Use This?

Reference the workflow code

## Links to Related Issues or Discussions

https://github.com/gruntwork-io/terragrunt-action/releases/tag/v3.0.0

### Contribution Reminders

Your PR needs:
- At least 5 thumbs up from members of the community to be approved / merged
- Final review / approval from at least one maintainer
- Clear, complete, and fully usable code for real-world systems
- No placeholder, unfinished, or copied code with incompatible licensing
- No redundant comments or unrelated artifacts
- The PR title to follow conventional commit standards

Refer the CONTRIBUTING guidelines and CODE_OF_CONDUCT for more information.
